### PR TITLE
ClassLoader getPackage filter

### DIFF
--- a/herman-core/src/main/java/com/digitalreasoning/herman/FilteredClassLoader.java
+++ b/herman-core/src/main/java/com/digitalreasoning/herman/FilteredClassLoader.java
@@ -184,4 +184,17 @@ class FilteredClassLoader extends ClassLoader
 			return extensionClassLoader.getResources(name);
 		}
 	}
+
+	@Override
+	protected Package getPackage(String name)
+	{
+		if(isIncluded(name, false))
+		{
+			return super.getPackage(name);
+		}
+		else
+		{
+			return null;
+		}
+	}
 }


### PR DESCRIPTION
Adding getPackage to FilteredClassLoader inorder to filter out certain package lookups to parent classloader.
